### PR TITLE
Fix for iOS sharing action

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,6 @@ class ShareViewController: SLComposeServiceViewController {
           let userDefaults = UserDefaults(suiteName: "group.\(this.hostAppBundleIdentifier)")
           userDefaults?.set(this.sharedText, forKey: this.sharedKey)
           userDefaults?.synchronize()
-           self?.didSelectPost();
           this.redirectToHostApp(type: .text)
         }
         
@@ -335,7 +334,6 @@ class ShareViewController: SLComposeServiceViewController {
           let userDefaults = UserDefaults(suiteName: "group.\(this.hostAppBundleIdentifier)")
           userDefaults?.set(this.sharedText, forKey: this.sharedKey)
           userDefaults?.synchronize()
-           self?.didSelectPost();
           this.redirectToHostApp(type: .text)
         }
         
@@ -366,7 +364,6 @@ class ShareViewController: SLComposeServiceViewController {
           let userDefaults = UserDefaults(suiteName: "group.\(this.hostAppBundleIdentifier)")
           userDefaults?.set(this.toData(data: this.sharedMedia), forKey: this.sharedKey)
           userDefaults?.synchronize()
-           self?.didSelectPost();
           this.redirectToHostApp(type: .media)
         }
         
@@ -400,7 +397,6 @@ class ShareViewController: SLComposeServiceViewController {
           let userDefaults = UserDefaults(suiteName: "group.\(this.hostAppBundleIdentifier)")
           userDefaults?.set(this.toData(data: this.sharedMedia), forKey: this.sharedKey)
           userDefaults?.synchronize()
-           self?.didSelectPost();
           this.redirectToHostApp(type: .media)
         }
         
@@ -429,7 +425,6 @@ class ShareViewController: SLComposeServiceViewController {
           let userDefaults = UserDefaults(suiteName: "group.\(this.hostAppBundleIdentifier)")
           userDefaults?.set(this.toData(data: this.sharedMedia), forKey: this.sharedKey)
           userDefaults?.synchronize()
-           self?.didSelectPost();
           this.redirectToHostApp(type: .file)
         }
         

--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ class ShareViewController: SLComposeServiceViewController {
   override func isContentValid() -> Bool {
     return true
   }
-  
-  override func viewDidLoad() {
+
+  override func didSelectPost() {
     // This is called after the user selects Post. Do the upload of contentText and/or NSExtensionContext attachments.
     if let content = extensionContext!.inputItems[0] as? NSExtensionItem {
       if let contents = content.attachments {
@@ -295,11 +295,7 @@ class ShareViewController: SLComposeServiceViewController {
       }
     }
   }
-  
-  override func didSelectPost() {
-    print("didSelectPost");
-  }
-  
+
   override func configurationItems() -> [Any]! {
     // To add configuration options via table cells at the bottom of the sheet, return an array of SLComposeSheetConfigurationItem here.
     return []

--- a/example/ios/Examples share/ShareViewController.swift
+++ b/example/ios/Examples share/ShareViewController.swift
@@ -25,8 +25,8 @@ class ShareViewController: SLComposeServiceViewController {
   override func isContentValid() -> Bool {
     return true
   }
-  
-  override func viewDidLoad() {
+
+  override func didSelectPost() {
     // This is called after the user selects Post. Do the upload of contentText and/or NSExtensionContext attachments.
     if let content = extensionContext!.inputItems[0] as? NSExtensionItem {
       if let contents = content.attachments {
@@ -46,11 +46,7 @@ class ShareViewController: SLComposeServiceViewController {
       }
     }
   }
-  
-  override func didSelectPost() {
-    print("didSelectPost");
-  }
-  
+
   override func configurationItems() -> [Any]! {
     // To add configuration options via table cells at the bottom of the sheet, return an array of SLComposeSheetConfigurationItem here.
     return []


### PR DESCRIPTION
`viewDidLoad` function should not be used, the way it's being used in the example, but instead `didSelectPost`should be used for the same purpose, because, `viewDidLoad` would immediately start to deal with the data passed in, whereas the data should only be
processed/acted on, when the user selects **Post**.

Without this change, no share action is shown as per below, but the user is immediately redirected to the main app. 

![image](https://user-images.githubusercontent.com/152363/83895342-14fc9880-a742-11ea-94ec-026155d121cd.png)


