### PR TITLE
Allow for custom protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ public void onNewIntent(Intent intent) {
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>ShareMedia</string>
+				<string>ShareMedia</string> <!-- share url protocol (must be unique to your app, suggest using your apple bundle id) -->
 			</array>
 		</dict>
 		<dict/>
@@ -289,6 +289,7 @@ import Photos
 class ShareViewController: SLComposeServiceViewController {
   // TODO: IMPORTANT: This should be your host app bundle identifier
   let hostAppBundleIdentifier = "com.ajith.example"
+  let shareProtocol = "ShareMedia" hostAppBundleIdentifier //share url protocol (must be unique to your app, suggest using your apple bundle id, ie: `hostAppBundleIdentifier`)
   let sharedKey = "ShareKey"
   var sharedMedia: [SharedMediaFile] = []
   var sharedText: [String] = []
@@ -475,7 +476,7 @@ class ShareViewController: SLComposeServiceViewController {
   }
   
   private func redirectToHostApp(type: RedirectType) {
-    let url = URL(string: "ShareMedia://dataUrl=\(sharedKey)#\(type)")
+    let url = URL(string: "\(shareProtocol)://dataUrl=\(sharedKey)#\(type)")
     var responder = self as UIResponder?
     let selectorOpenURL = sel_registerName("openURL:")
     
@@ -648,7 +649,9 @@ import ReceiveSharingIntent from 'react-native-receive-sharing-intent';
     }, 
     (error) =>{
       console.log(error);
-    });
+    }, 
+    'ShareMedia' // share url protocol (must be unique to your app, suggest using your apple bundle id)
+    );
     
     
     // To clear Intents

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,23 @@
+declare namespace ReceiveSharingIntent {
+    export interface ShareIntentFile {
+        filePath: string|null;
+        text: string|null;
+        weblink: string|null;
+        mimeType: string|null;
+        contentUri: string|null;
+        fileName: string|null;
+        extension: string|null;
+    }
+    
+    export type ShareIntentResponse = ShareIntentFile[];
+
+    export function getReceivedFiles(
+        callback: (files: ShareIntentResponse) => void,
+        errorHandler: (error: Error) => void,
+        protocol?: string
+    ): void;
+
+    export function clearReceivedFiles(): void;
+}
+
+export = ReceiveSharingIntent;

--- a/index.js
+++ b/index.js
@@ -7,17 +7,17 @@ const isIos = Platform.OS === 'ios';
 
 export default class ReceiveSharingIntentModule {
     
-    static getReceivedFiles = (handler, errorHandler) => {
+    static getReceivedFiles = (handler, errorHandler, protocol = 'ShareMedia') => {
         if (isIos) {
             Linking.getInitialURL().then(res => {
-                if (res && res.startsWith("ShareMedia://dataUrl")) {
+                if (res && res.startsWith(`${protocol}://dataUrl`)) {
                     this.getFileNames(handler, errorHandler, res);
                 }
             }).catch(e => { });
             Linking.addEventListener("url", (res) => {
                 console.log(res);
                 let url = res ? res.url : "";
-                if (url.startsWith("ShareMedia://dataUrl")) {
+                if (url.startsWith(`${protocol}://dataUrl`)) {
                     this.getFileNames(handler,errorHandler, res.url);
                 }
             });


### PR DESCRIPTION
iOS doesn't handle multiple apps having the same URL protocol very well.
https://stackoverflow.com/a/13130479

Resolves: https://github.com/ajith-ab/react-native-receive-sharing-intent/issues/45