### PR TITLE
Update ReceiveSharingIntentHelper when intent is null

### DIFF
--- a/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
+++ b/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
@@ -29,6 +29,7 @@ public class ReceiveSharingIntentHelper {
   @RequiresApi(api = Build.VERSION_CODES.KITKAT)
   public void sendFileNames(Context context, Intent intent, Promise promise){
     try {
+      if(intent == null) { return; }
       String action = intent.getAction();
       String type = intent.getType();
       if(type == null) { return; }


### PR DESCRIPTION
Has a try catch error on Android when i maximize my app without a intent shared (intent null)

[Error: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.String.toString()' on a null object reference]

With this validation the error will not be appears anymore <3