### PR TITLE
Missing check for null variable intent

### DIFF
--- a/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
+++ b/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
@@ -29,6 +29,7 @@ public class ReceiveSharingIntentHelper {
   @RequiresApi(api = Build.VERSION_CODES.KITKAT)
   public void sendFileNames(Context context, Intent intent, Promise promise){
     try {
+      if (intent == null) return;
       String action = intent.getAction();
       String type = intent.getType();
       if(type == null) { return; }


### PR DESCRIPTION
Silencing those errors  in my logs : 

[Error: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.Intent.getAction()' on a null object reference