### PR TITLE
Uses getExtOrIntegerDefault for minSDKVersion in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"


### PR DESCRIPTION
Uses `getExtOrIntegerDefault` function to use sdk versions from the root project

If the root project uses a minSdkVersion which is higher than 16, building the root project fails.

The error message:

```
Task :react-native-receive-sharing-intent:processDebugAndroidTestManifest FAILED
[androidx.vectordrawable:vectordrawable-animated:1.0.0] /home/dananussair/.gradle/caches/transforms-3/b73c4195544405c972c9d42c9310038f/transformed/vectordrawable-animated-1.0.0/AndroidManifest.xml Warning:
        Package name 'androidx.vectordrawable' used in: androidx.vectordrawable:vectordrawable-animated:1.0.0, androidx.vectordrawable:vectordrawable:1.0.1.
/home/dananussair/Development/kontist-app/node_modules/react-native-receive-sharing-intent/android/build/intermediates/tmp/manifest/androidTest/debug/manifestMerger1586576448122975393.xml:5:5-74 Error:
        uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-native:0.66.4] /home/dananussair/.gradle/caches/transforms-3/048d4de02ff09af1f27b43c86e129215/transformed/jetified-react-native-0.66.4/AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 21,
                or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)
```