### PR TITLE
Fix setIntent(null) issue

### DIFF
--- a/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java
+++ b/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java
@@ -4,14 +4,12 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
 
-
 import android.os.Build;
 import androidx.annotation.RequiresApi;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-
 
 public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
   public final String Log_Tag = "ReceiveSharingIntent";
@@ -26,31 +24,41 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
     receiveSharingIntentHelper = new ReceiveSharingIntentHelper(applicationContext);
   }
 
-
   protected void onNewIntent(Intent intent) {
     Activity mActivity = getCurrentActivity();
-    if(mActivity == null) { return; }
+    if (mActivity == null) {
+      return;
+    }
     mActivity.setIntent(intent);
   }
 
   @RequiresApi(api = Build.VERSION_CODES.KITKAT)
   @ReactMethod
-  public void getFileNames(Promise promise){
+  public void getFileNames(Promise promise) {
     Activity mActivity = getCurrentActivity();
-    if(mActivity == null) { return; }
+    if (mActivity == null) {
+      return;
+    }
     Intent intent = mActivity.getIntent();
     receiveSharingIntentHelper.sendFileNames(reactContext, intent, promise);
-    mActivity.setIntent(null);
+    String action = intent != null ? intent.getAction() : null;
+    if (action != null &&
+        (action.equals(android.content.Intent.ACTION_SEND) ||
+            action.equals(android.content.Intent.ACTION_SEND_MULTIPLE))) {
+      intent.setAction(null);
+      mActivity.setIntent(intent);
+    }
   }
 
   @ReactMethod
-  public void clearFileNames(){
+  public void clearFileNames() {
     Activity mActivity = getCurrentActivity();
-    if(mActivity == null) { return; }
+    if (mActivity == null) {
+      return;
+    }
     Intent intent = mActivity.getIntent();
     receiveSharingIntentHelper.clearFileNames(intent);
   }
-
 
   @Override
   public String getName() {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prettier": "^2.0.5",
     "react": "16.13.1",
     "react-native": "0.63.4",
-    "react-native-builder-bob": "^",
+    "react-native-builder-bob": "^0.20.0",
     "release-it": "^14.2.2",
     "typescript": "^4.1.3"
   },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,7 @@
-
 {
   "extends": "./tsconfig",
-  "exclude": ["example"]
+  "exclude": [
+    "example",
+    "docs"
+  ]
 }


### PR DESCRIPTION
Setting the intent to null caused a NullPointerException in firebase-dynamic-links package due to the old version of it we are using. In addition, setting the intent to null in this way can cause issues with a lot of third party libraries and RN modules that rely on the intent.